### PR TITLE
Adds menu button to kill all Spotify processes and relaunch.

### DIFF
--- a/SnipForMammal.Designer.cs
+++ b/SnipForMammal.Designer.cs
@@ -46,6 +46,7 @@ namespace SnipForMammal
             this.PictureBox = new System.Windows.Forms.PictureBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
+            this.toolStripMenuItem_RestartSpotify = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PictureBox)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
@@ -64,15 +65,16 @@ namespace SnipForMammal
             this.toolStripMenuItem_Version,
             this.toolStripSeparator1,
             this.toolStripMenuItem_TrackHistory,
+            this.toolStripMenuItem_CustomText,
             this.toolStripSeparator2,
             this.toolStripMenuItem_Settings,
-            this.toolStripMenuItem_CustomText,
             this.toolStripMenuItem_ForceUpdate,
+            this.toolStripMenuItem_RestartSpotify,
             this.toolStripMenuItem_ShowDebug,
             this.toolStripSeparator3,
             this.toolStripMenuItem_Exit});
             this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(188, 198);
+            this.contextMenuStrip.Size = new System.Drawing.Size(188, 220);
             // 
             // toolStripMenuItem_Version
             // 
@@ -184,6 +186,13 @@ namespace SnipForMammal
     "banana for your viewing pleasure.";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
+            // toolStripMenuItem_RestartSpotify
+            // 
+            this.toolStripMenuItem_RestartSpotify.Name = "toolStripMenuItem_RestartSpotify";
+            this.toolStripMenuItem_RestartSpotify.Size = new System.Drawing.Size(187, 22);
+            this.toolStripMenuItem_RestartSpotify.Text = "Restart Spotify";
+            this.toolStripMenuItem_RestartSpotify.Click += new System.EventHandler(this.toolStripMenuItem_RestartSpotify_Click);
+            // 
             // SnipForMammal
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -219,6 +228,7 @@ namespace SnipForMammal
         private System.Windows.Forms.PictureBox PictureBox;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem_RestartSpotify;
     }
 }
 

--- a/SnipForMammal.cs
+++ b/SnipForMammal.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using System.Timers;
 using System.Windows.Forms;
 
@@ -255,6 +257,66 @@ namespace SnipForMammal
         {
             // Prepare Snip file for next time use.
             InitializeSnipFile();
+        }
+
+        private void toolStripMenuItem_RestartSpotify_Click(object sender, EventArgs e)
+        {
+            bool result = KillSpotifyTasks();
+            if (!result)
+            {
+                LaunchSpotify();
+            }
+            else
+            {
+                MessageBox.Show("There was a problem closing all Spotify processes. Please close them manually in Task Manager.");
+            }
+            
+            
+        }
+
+        private bool KillSpotifyTasks()
+        {
+            Global.debugConsole?.WriteLine("Killing all Spotify processes.");
+            bool processAlive = false;
+
+            // Fetch all Spotify processes
+            Process[] allRunningProcesses = Process.GetProcessesByName("Spotify");
+            Global.debugConsole?.WriteLine("Found " + allRunningProcesses.Length + " processes");
+
+            if (allRunningProcesses.Length > 0)
+            {
+                processAlive = true;
+                // Kill all running Spotify processes
+                foreach (Process process in allRunningProcesses)
+                {
+                    Global.debugConsole?.WriteLine("    Killing PID " + process.Id);
+                    process.Kill();
+                }
+
+                // Pause before rechecking for processes
+                Thread.Sleep(100);
+
+                // Recheck for any Spotify processes. If some are still alive user will have to manually terminate.
+                allRunningProcesses = Process.GetProcessesByName("Spotify");
+                if (allRunningProcesses.Length > 0)
+                {
+                    processAlive = true;
+                    Global.debugConsole?.WriteLine("Not all Spotify processes were terminated. Manual termination needed in Task Manager.");
+                }
+                else
+                {
+                    processAlive = false;
+                    Global.debugConsole?.WriteLine("All Spotify processes successfully terminated.");
+                }
+            }
+
+            return processAlive;
+        }
+
+        private void LaunchSpotify()
+        {
+            Global.debugConsole?.WriteLine("Launching Spotify.");
+            Process.Start("Spotify");
         }
     }
 

--- a/SnipForMammal.csproj
+++ b/SnipForMammal.csproj
@@ -28,7 +28,7 @@
     <ProductName>SnipForMammal</ProductName>
     <PublisherName>Vetricci</PublisherName>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.1.0.%2a</ApplicationVersion>
+    <ApplicationVersion>1.2.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>


### PR DESCRIPTION
Sometimes Spotify becomes unresponsive and requires restarting, however not all the background processes close when closing the main window. This adds a button to kill all the processes and relaunch the Spotify process.